### PR TITLE
Fix demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 Javascript APIs for Jupyter output areas
 
 ## Demo
-See [./demo/demo.html](demo/demo.html).
+Run from /demo/data directory:
+```python
+python server.py
+```
+Then load [./demo/demo.html](demo/demo.html).
 
 ## Install
 ### Stable (npm):

--- a/demo/data/server.py
+++ b/demo/data/server.py
@@ -1,0 +1,44 @@
+#-----------------------------------------------------------------------------
+#  Copyright (c) 2015-, Jupyter Development Team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#
+# Import handling to support python 2 + 3
+#
+try:
+    from http.server import SimpleHTTPRequestHandler
+    import http.server as BaseHTTPServer
+except ImportError:
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    import BaseHTTPServer
+
+
+class CORSRequestHandler( SimpleHTTPRequestHandler ):
+    '''
+    This class provides an example server to allow local requests for the 
+    data.json file in this output area demo.
+
+    Making local file requests is not/should not be possible using the 
+    XmlHttpRequest handler (for security reasons); in general javascript
+    that fetches data from a different domain is frowned upon and is 
+    legitimately a security concern, hence XSS (cross-site scripting) is not
+    allowed.
+
+    The solution to this is to allow CORS (cross-origin resource sharing), which allows
+    the remote data to be fetched, but with much fewer security concerns than XSS.
+
+    CORS is enabled server-side (there's nothing the client can do to request it,
+    obviously) by adding the 'Access-Control-Allow-Origin' (ACAO) header to the 
+    http response.
+    '''
+    def end_headers( self ):
+        self.send_header( 'Access-Control-Allow-Origin', '*' )
+        SimpleHTTPRequestHandler.end_headers(self)
+
+        
+if __name__ == '__main__':
+    BaseHTTPServer.test( CORSRequestHandler, BaseHTTPServer.HTTPServer )

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -27,7 +27,7 @@
       });
   }
   
-  fetchJSONFile('./data/data.json').then(function(messages) {
+  fetchJSONFile('http://localhost:8000/data.json').then(function(messages) {
       var model = new jupyterOutputArea.OutputModel();
       var view = new jupyterOutputArea.OutputView(model, document);
       document.getElementById('screen').appendChild(view.el);


### PR DESCRIPTION
Currently the demo doesn't work.

The URL that's given to XMLHttpRequest is just a local file string ('./data/data.json') which has 2 problems:
- There's no way to complete the request. You _can_ use XmlHttpRequest to fetch local files, but if you do that you lose the request status information, in which case the logic in the fetchJSONFile Promise will never be resolved.
- If you did want to just make it use a local file, then firstly the logic in fetchJSONFile needs totally changed, and would therefore be different between demo/tests and reality, but more importantly you'd need a protocol specifier ('file://') for this to work at all.

We really don't want separate 'fetch' methods for a 'demo', we'd like it to be as close to reality as possible, so in this case I think the correct course of action is to put a very simple python server in the demo/data directory and ask people to fire that up in order to run the demo, which mimics the actual behaviour much more closely. This means I've only needed to change the fetchJSONFile _call_, not the _implementation_, which correctly handles different status requests, which as discussed above, just can't be done with local file access.

With these changes the demo actually shows the outputs.
