### PR TITLE
Fix traceback handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel": "^5.8.20",
     "browserify": "^11.0.1",
     "http-server": "^0.8.0",
+    "jsdom": "^6.2.0",
     "live-reload": "^1.1.0",
     "mkdirp": "^0.5.1",
     "nodemon": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/jupyter/jupyter-js-output-area#readme",
   "dependencies": {
     "transformime": "^2.0.0",
-    "transformime-jupyter-transformers": "^0.1.0"
+    "transformime-jupyter-transformers": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.20",

--- a/src/output-view.js
+++ b/src/output-view.js
@@ -16,20 +16,20 @@ import {
  * Displays output area state.
  */
 export class OutputView {
-    
+
     /**
      * Public constructor
      * @param  {OutputModel}  model    output model that this view represents
-     * @param  {Document}     document handle to the Document instance that 
+     * @param  {Document}     document handle to the Document instance that
      *                                 the output will be rendered in.
      */
     constructor(model, document) {
         this.model = model;
-        
+
         let el = document.createElement('div');
         this.getDocument = () => document;
         this.getEl = () => el;
-        
+
         // Transformers are in reverse priority order
         // so that new ones can be `push`ed on with higher priority
         let transformers = [
@@ -44,11 +44,11 @@ export class OutputView {
             // JavaScript would go here, IF I HAD ONE
         ];
         this.transformime = new Transformime(transformers);
-        
+
         // Bind events.
         this.model.on('change', this._modelChange.bind(this));
     }
-    
+
     /**
      * Document used for rendering.
      * @return {Document}
@@ -56,7 +56,7 @@ export class OutputView {
     get document() {
         return this.getDocument();
     }
-    
+
     /**
      * Container element.
      * @return {HTMLElement}
@@ -64,7 +64,7 @@ export class OutputView {
     get el() {
         return this.getEl();
     }
-    
+
     /**
      * Handle when the model changes.
      * @param {Output[]} newState new state of the model
@@ -76,9 +76,9 @@ export class OutputView {
         while (this.el.firstChild) {
             this.el.removeChild(this.el.firstChild);
         }
-        
+
         // Use transformime to render state.  Order promise is used to create a
-        // promise chain, which ensures the output gets rendered in the correct 
+        // promise chain, which ensures the output gets rendered in the correct
         // order.
         let orderPromise = Promise.resolve();
         for (let output of newState) {
@@ -91,7 +91,10 @@ export class OutputView {
                 case 'stream':
                     bundle = {'jupyter/console-text': output.data.text};
                     break;
-                case 'error' && output.traceback !== undefined:
+                case 'error':
+                    if (output.traceback === undefined) {
+                      break;
+                    }
                     // The parts that used to be the TracebackTransform
                     let text, traceback;
                     traceback = output.traceback;

--- a/src/output-view.js
+++ b/src/output-view.js
@@ -92,20 +92,25 @@ export class OutputView {
                     bundle = {'jupyter/console-text': output.data.text};
                     break;
                 case 'error':
+                    let text;
+                    console.log(output);
                     if (output.traceback === undefined) {
-                      break;
+                      text = output.ename + ": " + output.evalue;
+                    } else {
+                      // The parts that used to be the TracebackTransform
+                      let traceback;
+                      traceback = output.traceback;
+                      if (traceback.length > 0) {
+                          text = '';
+                          let len = traceback.length;
+                          for (let i=0; i<len; i++) {
+                              text = text + traceback[i] + '\n';
+                          }
+                          text = text + '\n';
+                      }
+
                     }
-                    // The parts that used to be the TracebackTransform
-                    let text, traceback;
-                    traceback = output.traceback;
-                    if (traceback.length > 0) {
-                        text = '';
-                        let len = traceback.length;
-                        for (let i=0; i<len; i++) {
-                            text = text + traceback[i] + '\n';
-                        }
-                        text = text + '\n';
-                    }
+
                     bundle = {'jupyter/console-text': text};
                     break;
                 default:


### PR DESCRIPTION
As noted in #10, tracebacks weren't being rendered appropriately, instead claiming that `'error'` was an unrecognized output type. This was due to extra logic sitting in the case statement. I broke this out and also handled the alternative to full tracebacks.

/cc @captainsafia @jdfreder 
