### PR TITLE
The `output` object has text and name keys.

### DIFF
--- a/src/output-view.js
+++ b/src/output-view.js
@@ -89,7 +89,7 @@ export class OutputView {
                     bundle = output.data;
                     break;
                 case 'stream':
-                    bundle = {'jupyter/console-text': output.data.text};
+                    bundle = {'jupyter/console-text': output.text};
                     break;
                 case 'error':
                     let text;


### PR DESCRIPTION
Fixes #13 
